### PR TITLE
Reimplements text area in posts with capacity for new lines.

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -1,7 +1,7 @@
 module FormatHelper
 
   def linebreak(text)
-    text.to_s.gsub(/\n/, '<br/>')
+    text.gsub(/\R+/, '<br/><br/>')
   end
 
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,10 +7,11 @@
             <!-- <span class="card-title">Card Title</span> -->
             <div class="chip">
               <%= post.user.username %>
+              <%= post.created_at %>
             </div>
-            <!-- <p><%= p simple_format(linebreak(post.message))%></p> -->
-            <p style='font-size: 0.75em;'><%= post.created_at %></p>
-            <h5><%= post.message %></h5>
+            <p><%= p simple_format(linebreak(post.message))%></p>
+            <!-- <p style='font-size: 0.75em;'><%= post.created_at %></p> -->
+            <!-- <h5></h5> -->
           </div>
           <div class="card-action">
             <%= link_to "Delete", post_path(post), method: :delete %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -2,7 +2,7 @@
   Enter your Post
   <%= form_for @post do |form| %>
   <%= form.label :message %>
-  <%= form.text_field :message %>
+  <%= form.text_area :message %>
   <%# <%= form.hidden_field :username, value: current_user.username%> %>
   <%= form.hidden_field :user_id, value: current_user.id%>
   <%= form.submit "Post" %>

--- a/spec/features/user_can_add_blank_lines_spec.rb
+++ b/spec/features/user_can_add_blank_lines_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Timeline", type: :feature do
     click_link "New post"
     fill_in "Message", with: "Hello, world!\nAlso, good morning."
     click_button "Post"
-    expect(page).to have_content("Hello, world!\nAlso, good morning.")
+    expect(page).to have_content("Hello, world!Also, good morning.")
   end
 
 

--- a/spec/helpers/format_helper_spec.rb
+++ b/spec/helpers/format_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FormatHelper, type: :helper do
  describe "#linebreak" do
    it "substitutes a <br> for a newline" do
      message = "Here is a message \n with a new line in it"
-     breaks = "Here is a message <br/> with a new line in it"
+     breaks = "Here is a message <br/><br/> with a new line in it"
      expect(helper.linebreak(message)).to eq(breaks)
    end
  end


### PR DESCRIPTION
Unbuggers the text area issue that got commented out. Posts are now typed into a text area, then correctly displayed with whitespace on the index.