### PR TITLE
Update within ten minutes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-console', require: false, group: :test
 # Use Uglifier as compressor for JavaScript assets
+gem 'timecop'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -222,6 +223,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   simplecov-console
+  timecop
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,9 +15,11 @@
           </div>
           <div class="card-action" style: >
             <% if current_user.id == post.user_id %>
-            <%= link_to "Delete", post_path(post), method: :delete %>
-            <%= link_to "Update", edit_post_path(post) %>
-            <%end%>
+              <%= link_to "Delete", post_path(post), method: :delete %>
+                <% unless Time.now > post.created_at + (Time.now +10*60) %> 
+                  <%= link_to "Update", edit_post_path(post) %>
+                  <%end%>
+            <%end%>  
           </div>
         </div>
       </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,10 +16,10 @@
           <div class="card-action" style: >
             <% if current_user.id == post.user_id %>
               <%= link_to "Delete", post_path(post), method: :delete %>
-                <% unless Time.now > post.created_at + (Time.now +10*60) %> 
-                  <%= link_to "Update", edit_post_path(post) %>
-                  <%end%>
-            <%end%>  
+              <% if post.created_at + 10.minutes > Time.now %> 
+                <%= link_to "Update", edit_post_path(post) %>
+              <%end%>
+            <%end%>
           </div>
         </div>
       </div>

--- a/spec/features/update_post_within_ten_minutes_spec.rb
+++ b/spec/features/update_post_within_ten_minutes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Can not update post adter ten minutes', type: :feature do
+  scenario 'can not update post after ten minutes' do
+    create_user
+    click_link 'New post'
+    fill_in 'Message', with: 'Testing User name'
+    click_button 'Post'
+    Timecop.freeze(Date.today + 1) do
+      expect(page).to have_no_link('Update')
+    end 
+  end
+end


### PR DESCRIPTION
Removes the update button for posts that are more than ten minutes old. Simples.